### PR TITLE
Updating CSL location to GitHub CDN Repository

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,17 +2,17 @@
 # https://maehr.github.io/academic-pandoc-template/
 
 # Project-specific values
-title: 'Accessible Map Generation in Unity'
-author: 'Jacob Allebach'
-date: '19 December 2023'
-firstreader: 'Janyl Jumadinova'
-secondreader: 'Oliver Bonham-Carter'
+title: 'Senior Thesis'
+author: 'Student Name'
+date: '22 July 2022'
+firstreader: 'First Reader'
+secondreader: 'Second Reader'
 logo: 'images/logo'
 
 # Template Values: DO NOT TOUCH
 
 # Bibliography
-csl: https://www.zotero.org/styles/journal-of-the-acm # See https://www.zotero.org/styles for more styles.
+csl: https://cdn.githubraw.com/ReadyResearchers-2023-24/thesis-resources-cdn/main/cdn/journal-of-the-acm.csl # See https://www.zotero.org/styles for more styles.
 bibliography: references.bib # See https://github.com/jgm/pandoc-citeproc/blob/master/man/pandoc-citeproc.1.md for more formats.
 suppress-bibliography: false
 link-citations: true


### PR DESCRIPTION
Substituting the old Zotero GitHub using githubraw as a CDN to serve the CSL files required for building the thesis document, as Zotero proper isn't answering our calls.